### PR TITLE
added basic trivy options to test canary repo

### DIFF
--- a/generator/common-pipeline.go
+++ b/generator/common-pipeline.go
@@ -15,6 +15,10 @@ steps:
 - command: ls
   plugins:
     - equinixmetal-buildkite/trivy#%s
+	    severity: CRITICAL,HIGH
+	    ignore-unfixed: true
+	    security-checks: config,secret,vuln
+	    skip-files: 'cosign.key'
 - label: ":sparkles: SHELL CHECK"
   plugins:
     - shellcheck#%s:

--- a/generator/common-pipeline.go
+++ b/generator/common-pipeline.go
@@ -1,33 +1,41 @@
 package generator
 
 import (
-	"fmt"
 	"io"
+	"strings"
+	"text/template"
 )
+
+// Generator is the struct to keep the values passed to the trivy step template
+type Generator struct {
+	TrivyPlugin    string
+	ShellPlugin    string
+	Severity       []string
+	IgnoreUnfixed  bool
+	SecurityChecks []string
+	SkipFiles      string
+}
 
 // GenerateTrivyStep takes trivy plugin version and shell plugin version
 // and an io.Writer to generate trivy step configuration. The trivy step is
 // written to the provided io.Writer.
 // It returns error in case write to the io.Writer errors out.
 func GenerateTrivyStep(trivyPlugin, shellPlugin string, w io.Writer) error {
-	trivyStepFormat := `
-steps:
-- command: ls
-  plugins:
-    - equinixmetal-buildkite/trivy#%s
-	    severity: CRITICAL,HIGH
-	    ignore-unfixed: true
-	    security-checks: config,secret,vuln
-	    skip-files: 'cosign.key'
-- label: ":sparkles: SHELL CHECK"
-  plugins:
-    - shellcheck#%s:
-        files: script.sh
-`
-
-	trivyStep := fmt.Sprintf(trivyStepFormat, trivyPlugin, shellPlugin)
-	if _, err := w.Write([]byte(trivyStep)); err != nil {
-		return fmt.Errorf("error writing trivy step to the output stream: %w", err)
+	generator := Generator{
+		TrivyPlugin:    trivyPlugin,
+		ShellPlugin:    shellPlugin,
+		Severity:       []string{"CRITICAL", "HIGH"},
+		IgnoreUnfixed:  true,
+		SecurityChecks: []string{"config", "secret", "vuln"},
+		SkipFiles:      "cosign.key",
 	}
-	return nil
+
+	funcMap := template.FuncMap{
+		"join": func(arr []string) string {
+			return strings.Join(arr, ",")
+		},
+	}
+
+	tpl := template.Must(template.New("").Funcs(funcMap).ParseGlob("templates/*"))
+	return tpl.ExecuteTemplate(w, "trivy-step.tmpl", generator)
 }

--- a/templates/trivy-step.tmpl
+++ b/templates/trivy-step.tmpl
@@ -1,0 +1,12 @@
+steps:
+- command: ls
+  plugins:
+    - equinixmetal-buildkite/trivy#{{ .TrivyPlugin }}
+	    severity: {{ .Severity }}
+	    ignore-unfixed: {{ .IgnoreUnfixed }}
+	    security-checks: {{ join .SecurityChecks }}
+	    skip-files: '{{ .SkipFiles }}'
+- label: ":sparkles: SHELL CHECK"
+  plugins:
+    - shellcheck#{{ .ShellPlugin }}:
+        files: script.sh


### PR DESCRIPTION
Desc:

- Need to add some(basic) trivy options to test dynamic pipeline from canary repos. In this PR we have to add ```severity, security-checks, ignore-unfixed values, and for time being I'm adding hard coding skip-files with one value```. 

- Created templates folder and added the ```trivy-step.tmpl```

Note: I need to figure out a way to allow consumer pipelines to pass these values dynamically.