### PR TITLE
fix TestGetLatestTag

### DIFF
--- a/util/github.go
+++ b/util/github.go
@@ -2,10 +2,16 @@ package util
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
+)
+
+var (
+	ErrRequestingLatestTag = errors.New("error requesting latest tag")
+	ErrFetchingLatestTag   = errors.New("error fetching latest tag")
 )
 
 // GithubLatestReleaseResponse is used to unmarshal the response while fetching the github latest release
@@ -26,7 +32,9 @@ func GetLatestTag(gitToken, githubOrg, repo string) (string, error) {
 		return "", fmt.Errorf("error while creating request to fetch the latest tag: %w", err)
 	}
 	req.Header.Add("Accept", "application/vnd.github+json")
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", gitToken))
+	if gitToken != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", gitToken))
+	}
 	req.Header.Add("X-GitHub-Api-Version", "2022-11-28")
 
 	client := http.Client{
@@ -35,12 +43,16 @@ func GetLatestTag(gitToken, githubOrg, repo string) (string, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("error while sending request to fetch the latest tag: %w", err)
+		return "", fmt.Errorf("%w: %s", ErrRequestingLatestTag, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("error while fetching latest tag. Status Code: %d", resp.StatusCode)
+		errMsg := resp.Status
+		if body, err := io.ReadAll(resp.Body); err == nil {
+			errMsg = fmt.Sprintf("%s: %s", errMsg, body)
+		}
+		return "", fmt.Errorf("%w: %s", ErrFetchingLatestTag, errMsg)
 	}
 
 	b, err := io.ReadAll(resp.Body)
@@ -56,4 +68,3 @@ func GetLatestTag(gitToken, githubOrg, repo string) (string, error) {
 
 	return ghLastestReleaseResp.TagName, nil
 }
-


### PR DESCRIPTION
currently, if the github token is not set, the app will fail (even against public repos):
```
% echo $GITHUB_PAT

```
```
% go run main.go trivy
{"level":"fatal","msg":"error while fetching latest tag. Status Code: 401","time":"2023-08-12T15:57:20+01:00"}
exit status 1
```
also, the tests are failing for the same reason:
```
% go test ./...
?   	dynamic-buildkite-template	[no test files]
?   	dynamic-buildkite-template/cmd	[no test files]
?   	dynamic-buildkite-template/config	[no test files]
ok  	dynamic-buildkite-template/generator	0.479s
--- FAIL: TestGetLatestTag (0.43s)
    --- FAIL: TestGetLatestTag/PAT_provided (0.27s)
        github_test.go:53: Error error while fetching latest tag. Status Code: 401 is not nil
FAIL
FAIL	dynamic-buildkite-template/util	1.001s
FAIL
```

this pr tries to fix that, adds more descriptive error and refactor tests - example outputs:

> error fetching latest tag: 403 Forbidden: {"message":"Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.","documentation_url":"https://docs.github.com/articles/authenticating-to-a-github-organization-with-saml-single-sign-on/"}

```
$ go test -v ./...
?       dynamic-buildkite-template      [no test files]
?       dynamic-buildkite-template/cmd  [no test files]
=== RUN   TestGenerateTrivyStep
=== RUN   TestGenerateTrivyStep/success
=== RUN   TestGenerateTrivyStep/wrong_template_path
--- PASS: TestGenerateTrivyStep (0.00s)
    --- PASS: TestGenerateTrivyStep/success (0.00s)
    --- PASS: TestGenerateTrivyStep/wrong_template_path (0.00s)
PASS
ok      dynamic-buildkite-template/generator    0.001s
=== RUN   TestGetLatestTag
=== RUN   TestGetLatestTag/PublicRepo
=== RUN   TestGetLatestTag/PublicRepo/ValidPAT
=== RUN   TestGetLatestTag/PublicRepo/InvalidPAT
=== RUN   TestGetLatestTag/PublicRepo/NoPAT
=== RUN   TestGetLatestTag/PrivateRepo
=== RUN   TestGetLatestTag/PrivateRepo/ValidPAT
=== RUN   TestGetLatestTag/PrivateRepo/InvalidPAT
=== RUN   TestGetLatestTag/PrivateRepo/NoPAT
--- PASS: TestGetLatestTag (0.96s)
    --- PASS: TestGetLatestTag/PublicRepo (0.60s)
        --- PASS: TestGetLatestTag/PublicRepo/ValidPAT (0.27s)
        --- PASS: TestGetLatestTag/PublicRepo/InvalidPAT (0.15s)
        --- PASS: TestGetLatestTag/PublicRepo/NoPAT (0.18s)
    --- PASS: TestGetLatestTag/PrivateRepo (0.36s)
        --- PASS: TestGetLatestTag/PrivateRepo/ValidPAT (0.19s)
        --- PASS: TestGetLatestTag/PrivateRepo/InvalidPAT (0.14s)
        --- PASS: TestGetLatestTag/PrivateRepo/NoPAT (0.02s)
PASS
ok      dynamic-buildkite-template/util 0.960s
```
```
$ go run . trivy
steps:
  - command: ls
    plugins:
      - equinixmetal-buildkite/trivy#v1.18.2:
          timeout : 5m0s
          severity: HIGH,CRITICAL
          ignore-unfixed: true
          security-checks: vuln,config
```