### PR TITLE
Config file is being sent from flag

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -28,20 +28,21 @@ This Program generates step for the provided plugins with configurations
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	generateCmd.PersistentFlags().StringVar(&ConfigFilePath, "config", "", fmt.Sprintf("Mention the config file path (default \"%s\")", defaultConfigFilePath))
+	generateCmd.PersistentFlags().StringVar(&ConfigFilePath, "config", "", fmt.Sprintf("config file path (default %q)", defaultConfigFilePath))
 }
 
 func initConfig() {
 	if ConfigFilePath != "" {
-		log.Debug("Config Path:", ConfigFilePath)
+		log.Debug("config path: ", ConfigFilePath)
 		if err := config.LoadConfig(ConfigFilePath); err != nil {
-			log.Fatal("Error while loading the configuration file. Exiting the program.")
+			log.Fatal("error while loading the configuration file. Exiting the program.")
 		}
-	} else {
-		log.Debug("Config Path:", defaultConfigFilePath)
-		if err := config.LoadConfig(defaultConfigFilePath); err != nil {
-			log.Debug("Error while loading the configuration file. Loading the defaults")
-		}
+		return
+	}
+
+	log.Debug("config path:", defaultConfigFilePath)
+	if err := config.LoadConfig(defaultConfigFilePath); err != nil {
+		log.Debug("error while loading the configuration file. Loading the defaults")
 	}
 }
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -3,14 +3,16 @@ package cmd
 import (
 	"dynamic-buildkite-template/config"
 	"dynamic-buildkite-template/generator"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 var (
-	g              = generator.Generator{}
-	ConfigFilePath string
+	g                     = generator.Generator{}
+	ConfigFilePath        string
+	defaultConfigFilePath = "conf.yaml"
 )
 
 var generateCmd = &cobra.Command{
@@ -26,14 +28,19 @@ This Program generates step for the provided plugins with configurations
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	generateCmd.PersistentFlags().StringVar(&ConfigFilePath, "config", "conf.yaml", "Mention the config file path")
+	generateCmd.PersistentFlags().StringVar(&ConfigFilePath, "config", "", fmt.Sprintf("Mention the config file path (default \"%s\")", defaultConfigFilePath))
 }
 
 func initConfig() {
 	if ConfigFilePath != "" {
 		log.Debug("Config Path:", ConfigFilePath)
 		if err := config.LoadConfig(ConfigFilePath); err != nil {
-			log.Warn("Error while loading the configuration file. Loading the defaults")
+			log.Fatal("Error while loading the configuration file. Exiting the program.")
+		}
+	} else {
+		log.Debug("Config Path:", defaultConfigFilePath)
+		if err := config.LoadConfig(defaultConfigFilePath); err != nil {
+			log.Debug("Error while loading the configuration file. Loading the defaults")
 		}
 	}
 }

--- a/cmd/trivy.go
+++ b/cmd/trivy.go
@@ -49,12 +49,12 @@ func CreateGenerator(cmd *cobra.Command, args []string) {
 	s := viper.Sub("plugins.trivy")
 	doLookup := true
 	if s == nil {
-		log.Debug("Trivy Plugin configuration not found in the config file or wrong config file. Proceeding with defaults from command line flags.")
+		log.Debug("trivy plugin configuration not found in the config file or wrong config file. Proceeding with defaults from command line flags.")
 		doLookup = false
 	} else {
 		err := s.Unmarshal(&trivyPluginConfig)
 		if err != nil {
-			log.Error("Error unmarshalling config file", err)
+			log.Error("error unmarshalling config file", err)
 		}
 	}
 

--- a/cmd/trivy.go
+++ b/cmd/trivy.go
@@ -49,7 +49,7 @@ func CreateGenerator(cmd *cobra.Command, args []string) {
 	s := viper.Sub("plugins.trivy")
 	doLookup := true
 	if s == nil {
-		log.Warn("Trivy Plugin configuration not found in the config file or wrong config file. Proceeding with defaults from command line flags.")
+		log.Debug("Trivy Plugin configuration not found in the config file or wrong config file. Proceeding with defaults from command line flags.")
 		doLookup = false
 	} else {
 		err := s.Unmarshal(&trivyPluginConfig)

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -44,7 +44,7 @@ func setFromIntFlag(f *int, cmd *cobra.Command, name string, doLookup bool) {
 func mustGetStringFlag(cmd *cobra.Command, name string) string {
 	flagVal, err := cmd.Flags().GetString(name)
 	if err != nil {
-		log.Fatalf("Failed to get value of %s. %s", name, err.Error())
+		log.Fatalf("failed to get value of %s. %s", name, err.Error())
 	}
 	return flagVal
 }
@@ -52,7 +52,7 @@ func mustGetStringFlag(cmd *cobra.Command, name string) string {
 func mustGetBoolFlag(cmd *cobra.Command, name string) bool {
 	flagVal, err := cmd.Flags().GetBool(name)
 	if err != nil {
-		log.Fatalf("Failed to get value of %s. %s", name, err.Error())
+		log.Fatalf("failed to get value of %s. %s", name, err.Error())
 	}
 	return flagVal
 }
@@ -60,7 +60,7 @@ func mustGetBoolFlag(cmd *cobra.Command, name string) bool {
 func mustGetIntFlag(cmd *cobra.Command, name string) int {
 	flagVal, err := cmd.Flags().GetInt(name)
 	if err != nil {
-		log.Fatalf("Failed to get value of %s. %s", name, err.Error())
+		log.Fatalf("failed to get value of %s. %s", name, err.Error())
 	}
 	return flagVal
 }
@@ -73,6 +73,6 @@ func GetLatestTrivyPluginTag() string {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Info("Latest trivy plugin tag:", tag)
+	log.Info("latest trivy plugin tag: ", tag)
 	return tag
 }

--- a/conf.yaml
+++ b/conf.yaml
@@ -1,7 +1,7 @@
 plugins:
   trivy:
     exit-code: 0
-    timeout: 51m0s
+    timeout: 5m0s
     severity: HIGH
     ignore-unfixed: true
     security-checks: vuln,config

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func init() {
 	log.SetOutput(os.Stderr)
 
 	// Only log the error severity or above.
-	log.SetLevel(log.ErrorLevel)
+	log.SetLevel(log.DebugLevel)
 }
 func main() {
 


### PR DESCRIPTION
Desc: 
Config file is being sent from flag ``` --config ``` and it's not defined then it would pick from default ```conf.ymal```.
If ```config.yaml``` file is missing then default values from command line flags would be used. If a file is passed to --config flag which doesn't exist then it would throw a fatal error and exit the program.

[JIRA ticket](https://packet.atlassian.net/browse/SCT-440)

o/p:

```
go run . trivy
{"level":"debug","msg":"Config Path:conf.yaml","time":"2023-09-07T12:09:42+01:00"}
{"level":"info","msg":"Latest trivy plugin tag:v1.18.2","time":"2023-09-07T12:09:42+01:00"}
steps:
  - command: ls
    plugins:
      - equinixmetal-buildkite/trivy#v1.18.2:
          timeout : 5m0s
          severity: "HIGH"
          ignore-unfixed: true
          security-checks: "vuln,config"               
```

````
go run . trivy --config=xyz.yaml
{"level":"debug","msg":"Config Path:xyz.yaml","time":"2023-09-07T12:10:09+01:00"}
{"level":"fatal","msg":"Error while loading the configuration file. Exiting the program.","time":"2023-09-07T12:10:09+01:00"}
exit status 1
```

rm conf.yaml then run the below command

```
go run . trivy                  
{"level":"debug","msg":"Config Path:conf.yaml","time":"2023-09-07T12:11:11+01:00"}
{"level":"debug","msg":"Error while loading the configuration file. Loading the defaults","time":"2023-09-07T12:11:11+01:00"}
{"level":"debug","msg":"Trivy Plugin configuration not found in the config file or wrong config file. Proceeding with defaults from command line flags.","time":"2023-09-07T12:11:11+01:00"}
{"level":"info","msg":"Latest trivy plugin tag:v1.18.2","time":"2023-09-07T12:11:11+01:00"}
steps:
  - command: ls
    plugins:
      - equinixmetal-buildkite/trivy#v1.18.2:
          timeout : 5m0s
          severity: "HIGH,CRITICAL"
          ignore-unfixed: true
          security-checks: "vuln,config"
```

