### PR TITLE
update to show Zero values as in the ticket SCT-439

### DIFF
--- a/cmd/trivy.go
+++ b/cmd/trivy.go
@@ -58,6 +58,38 @@ func CreateGenerator(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	// initializing nil fields for the cases when conf file is not present or there is command line flag override
+	if (!doLookup || cmd.Flags().Lookup("exit-code").Changed) && trivyPluginConfig.ExitCode == nil {
+		trivyPluginConfig.ExitCode = new(int)
+	}
+	if (!doLookup || cmd.Flags().Lookup("timeout").Changed) && trivyPluginConfig.Timeout == nil {
+		trivyPluginConfig.Timeout = new(string)
+	}
+	if (!doLookup || cmd.Flags().Lookup("severity").Changed) && trivyPluginConfig.Severity == nil {
+		trivyPluginConfig.Severity = new(string)
+	}
+	if (!doLookup || cmd.Flags().Lookup("ignore-unfixed").Changed) && trivyPluginConfig.IgnoreUnfixed == nil {
+		trivyPluginConfig.IgnoreUnfixed = new(bool)
+	}
+	if (!doLookup || cmd.Flags().Lookup("security-checks").Changed) && trivyPluginConfig.SecurityChecks == nil {
+		trivyPluginConfig.SecurityChecks = new(string)
+	}
+	if (!doLookup || cmd.Flags().Lookup("skip-files").Changed) && trivyPluginConfig.SkipFiles == nil {
+		trivyPluginConfig.SkipFiles = new(string)
+	}
+	if (!doLookup || cmd.Flags().Lookup("skip-dirs").Changed) && trivyPluginConfig.SkipDirs == nil {
+		trivyPluginConfig.SkipDirs = new(string)
+	}
+	if (!doLookup || cmd.Flags().Lookup("image-ref").Changed) && trivyPluginConfig.ImageRef == nil {
+		trivyPluginConfig.ImageRef = new(string)
+	}
+	if (!doLookup || cmd.Flags().Lookup("version").Changed) && trivyPluginConfig.TrivyVersion == nil {
+		trivyPluginConfig.TrivyVersion = new(string)
+	}
+	if (!doLookup || cmd.Flags().Lookup("helm-overrides-file").Changed) && trivyPluginConfig.HelmOverridesFile == nil {
+		trivyPluginConfig.HelmOverridesFile = new(string)
+	}
+
 	setFromIntFlag(trivyPluginConfig.ExitCode, cmd, "exit-code", doLookup)
 	setFromStringFlag(trivyPluginConfig.Timeout, cmd, "timeout", doLookup)
 	setFromStringFlag(trivyPluginConfig.Severity, cmd, "severity", doLookup)
@@ -69,6 +101,9 @@ func CreateGenerator(cmd *cobra.Command, args []string) {
 	setFromStringFlag(trivyPluginConfig.TrivyVersion, cmd, "version", doLookup)
 	setFromStringFlag(trivyPluginConfig.HelmOverridesFile, cmd, "helm-overrides-file", doLookup)
 
+	if trivyPluginConfig.TrivyVersion == nil {
+		trivyPluginConfig.TrivyVersion = new(string)
+	}
 	if strings.TrimSpace(*trivyPluginConfig.TrivyVersion) == "" {
 		lv := GetLatestTrivyPluginTag()
 		trivyPluginConfig.TrivyVersion = &lv

--- a/cmd/trivy.go
+++ b/cmd/trivy.go
@@ -58,19 +58,20 @@ func CreateGenerator(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	setFromIntFlag(&trivyPluginConfig.ExitCode, cmd, "exit-code", doLookup)
-	setFromStringFlag(&trivyPluginConfig.Timeout, cmd, "timeout", doLookup)
-	setFromStringFlag(&trivyPluginConfig.Severity, cmd, "severity", doLookup)
-	setFromBoolFlag(&trivyPluginConfig.IgnoreUnfixed, cmd, "ignore-unfixed", doLookup)
-	setFromStringFlag(&trivyPluginConfig.SecurityChecks, cmd, "security-checks", doLookup)
-	setFromStringFlag(&trivyPluginConfig.SkipFiles, cmd, "skip-files", doLookup)
-	setFromStringFlag(&trivyPluginConfig.SkipDirs, cmd, "skip-dirs", doLookup)
-	setFromStringFlag(&trivyPluginConfig.ImageRef, cmd, "image-ref", doLookup)
-	setFromStringFlag(&trivyPluginConfig.TrivyVersion, cmd, "version", doLookup)
-	setFromStringFlag(&trivyPluginConfig.HelmOverridesFile, cmd, "helm-overrides-file", doLookup)
+	setFromIntFlag(trivyPluginConfig.ExitCode, cmd, "exit-code", doLookup)
+	setFromStringFlag(trivyPluginConfig.Timeout, cmd, "timeout", doLookup)
+	setFromStringFlag(trivyPluginConfig.Severity, cmd, "severity", doLookup)
+	setFromBoolFlag(trivyPluginConfig.IgnoreUnfixed, cmd, "ignore-unfixed", doLookup)
+	setFromStringFlag(trivyPluginConfig.SecurityChecks, cmd, "security-checks", doLookup)
+	setFromStringFlag(trivyPluginConfig.SkipFiles, cmd, "skip-files", doLookup)
+	setFromStringFlag(trivyPluginConfig.SkipDirs, cmd, "skip-dirs", doLookup)
+	setFromStringFlag(trivyPluginConfig.ImageRef, cmd, "image-ref", doLookup)
+	setFromStringFlag(trivyPluginConfig.TrivyVersion, cmd, "version", doLookup)
+	setFromStringFlag(trivyPluginConfig.HelmOverridesFile, cmd, "helm-overrides-file", doLookup)
 
-	if strings.TrimSpace(trivyPluginConfig.TrivyVersion) == "" {
-		trivyPluginConfig.TrivyVersion = GetLatestTrivyPluginTag()
+	if strings.TrimSpace(*trivyPluginConfig.TrivyVersion) == "" {
+		lv := GetLatestTrivyPluginTag()
+		trivyPluginConfig.TrivyVersion = &lv
 	}
 	g.TPConfig = trivyPluginConfig
 	generator.GenerateTrivyStep(g, os.Stdout, "templates/*")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -12,6 +12,9 @@ import (
 func setFromStringFlag(f *string, cmd *cobra.Command, name string, doLookup bool) {
 	// if doLookup is set then it would check for command line overrides before overriding the configuration
 	// if doLookup is not set then it would pick the from default command line flag values
+	if f == nil {
+		return
+	}
 	if doLookup {
 		if cmd.Flags().Lookup(name).Changed {
 			*f = mustGetStringFlag(cmd, name)
@@ -22,6 +25,9 @@ func setFromStringFlag(f *string, cmd *cobra.Command, name string, doLookup bool
 }
 
 func setFromBoolFlag(f *bool, cmd *cobra.Command, name string, doLookup bool) {
+	if f == nil {
+		return
+	}
 	if doLookup {
 		if cmd.Flags().Lookup(name).Changed {
 			*f = mustGetBoolFlag(cmd, name)
@@ -32,6 +38,9 @@ func setFromBoolFlag(f *bool, cmd *cobra.Command, name string, doLookup bool) {
 }
 
 func setFromIntFlag(f *int, cmd *cobra.Command, name string, doLookup bool) {
+	if f == nil {
+		return
+	}
 	if doLookup {
 		if cmd.Flags().Lookup(name).Changed {
 			*f = mustGetIntFlag(cmd, name)

--- a/conf.yaml
+++ b/conf.yaml
@@ -1,7 +1,7 @@
 plugins:
   trivy:
     exit-code: 0
-    timeout: 51m0s
+    timeout: 5m0s
     severity: HIGH
     ignore-unfixed: true
     security-checks: vuln,config
@@ -9,4 +9,4 @@ plugins:
     skip-dirs: ""
     image-ref: ""
     version: ""
-    helm-overrides-files: ""
+    helm-overrides-file: ""

--- a/conf.yaml
+++ b/conf.yaml
@@ -2,7 +2,6 @@ plugins:
   trivy:
     exit-code: 0
     timeout: 5m0s
-    timeout: 5m0s
     severity: HIGH
     ignore-unfixed: true
     security-checks: vuln,config

--- a/generator/common-pipeline.go
+++ b/generator/common-pipeline.go
@@ -15,16 +15,16 @@ type Generator struct {
 
 // TrivyPluginConfig stores the various configurations for trivy plugin
 type TrivyPluginConfig struct {
-	ExitCode          int    `mapstructure:"exit-code"`
-	Timeout           string `mapstructure:"timeout"`
-	Severity          string `mapstructure:"severity"`
-	IgnoreUnfixed     bool   `mapstructure:"ignore-unfixed"`
-	SecurityChecks    string `mapstructure:"security-checks"`
-	SkipFiles         string `mapstructure:"skip-files"`
-	SkipDirs          string `mapstructure:"skip-dirs"`
-	ImageRef          string `mapstructure:"image-ref"`
-	TrivyVersion      string `mapstructure:"version"`
-	HelmOverridesFile string `mapstructure:"helm-overrides-file"`
+	ExitCode          *int    `mapstructure:"exit-code"`
+	Timeout           *string `mapstructure:"timeout"`
+	Severity          *string `mapstructure:"severity"`
+	IgnoreUnfixed     *bool   `mapstructure:"ignore-unfixed"`
+	SecurityChecks    *string `mapstructure:"security-checks"`
+	SkipFiles         *string `mapstructure:"skip-files"`
+	SkipDirs          *string `mapstructure:"skip-dirs"`
+	ImageRef          *string `mapstructure:"image-ref"`
+	TrivyVersion      *string `mapstructure:"version"`
+	HelmOverridesFile *string `mapstructure:"helm-overrides-file"`
 }
 
 // GenerateTrivyStep takes trivy plugin version and shell plugin version

--- a/generator/common-pipeline_test.go
+++ b/generator/common-pipeline_test.go
@@ -15,17 +15,22 @@ type testCase struct {
 }
 
 func TestGenerateTrivyStep(t *testing.T) {
+	testSeverity := "CRITICAL,HIGH"
+	testSecurityChecks := "config,secret,vuln"
+	testIgnoreUnfixed := true
+	testSkipFiles := "cosign.key"
+
 	tpc := TrivyPluginConfig{
-		Severity:       "CRITICAL,HIGH",
-		SecurityChecks: "config,secret,vuln",
-		IgnoreUnfixed:  true,
-		SkipFiles:      "cosign.key",
+		Severity:       &testSeverity,
+		SecurityChecks: &testSecurityChecks,
+		IgnoreUnfixed:  &testIgnoreUnfixed,
+		SkipFiles:      &testSkipFiles,
 	}
 	expected := `
 steps:
   - command: ls
     plugins:
-      - equinixmetal-buildkite/trivy#:
+      - equinixmetal-buildkite/trivy#<nil>:
           severity: "CRITICAL,HIGH"
           ignore-unfixed: true
           security-checks: "config,secret,vuln"

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func init() {
 	log.SetOutput(os.Stderr)
 
 	// Only log the error severity or above.
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(log.ErrorLevel)
 }
 func main() {
 

--- a/templates/trivy-step.tmpl
+++ b/templates/trivy-step.tmpl
@@ -7,7 +7,7 @@ steps:
           exit-code: {{ .TPConfig.ExitCode }}
           {{- end }}
           {{- if .TPConfig.Timeout}}
-          timeout : {{ .TPConfig.Timeout }}
+          timeout : "{{ .TPConfig.Timeout }}"
           {{- end }}
           {{- if .TPConfig.Severity}}
           severity: "{{ .TPConfig.Severity }}"
@@ -27,7 +27,7 @@ steps:
           {{- if .TPConfig.ImageRef}}
           image-ref: "{{ .TPConfig.ImageRef }}"
           {{- end }}
-          {{- if .TPConfig.HelmOverridesFiles}}
-          helm-overrides-file: "{{ .TPConfig.HelmOverridesFiles }}"
+          {{- if .TPConfig.HelmOverridesFile}}
+          helm-overrides-file: "{{ .TPConfig.HelmOverridesFile }}"
           {{- end }}
 {{- end}}


### PR DESCRIPTION
Desc:
The code has been modified to show zero values as in the ticket([SCT-439](https://packet.atlassian.net/browse/SCT-439)).
If a configuration is not present in the default config then that value won't come from the template as it checks for null values.

```
plugins:
    trivy:
       exit-code: 0
       timeout : 5m0s
       severity: HIGH
       ignore-unfixed: true
       security-checks: vuln,config
          skip-files: ""
          skip-dirs: ""
          image-ref: ""
          helm-overrides-file: ""
```

```
go run . trivy
steps:
  - command: ls
    plugins:
      - equinixmetal-buildkite/trivy#v1.18.2:
          exit-code: 0
          timeout : "5m0s"
          severity: "HIGH"
          ignore-unfixed: true
          security-checks: "vuln,config"
          skip-files: ""
          skip-dirs: ""
          image-ref: ""
          helm-overrides-file: ""
```

```
go run . trivy --exit-code=0 --ignore-unfixed=false
steps:
  - command: ls
    plugins:
      - equinixmetal-buildkite/trivy#v1.18.2:
          exit-code: 0
          timeout : "5m0s"
          severity: "HIGH"
          ignore-unfixed: false
          security-checks: "vuln,config"
          skip-files: ""
          skip-dirs: ""
          image-ref: ""
          helm-overrides-file: ""

go run . trivy --exit-code=42 --ignore-unfixed=false
steps:
  - command: ls
    plugins:
      - equinixmetal-buildkite/trivy#v1.18.2:
          exit-code: 42
          timeout : "5m0s"
          severity: "HIGH"
          ignore-unfixed: false
          security-checks: "vuln,config"
          skip-files: ""
          skip-dirs: ""
          image-ref: ""
          helm-overrides-file: ""
```