### PR TITLE
add command configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,46 @@ make deb
 # Usage
 Here's how you can generate the buildkite template
 ```
-$ ./dynamic-buildkite-template
+$ go run main.go
 steps:
   - command: ls
     plugins:
-      - equinixmetal-buildkite/cosign#v0.1.0:
+      - equinixmetal-buildkite/docker-build#v1.1.0:
+          build-args:
+            - NAME=REPO_NAME
+          push: true
+      - ssh://git@github.com/equinixmetal/ssm-buildkite-plugin#v1.0.4:
+          parameters:
+            COSIGN_KEY_SECRET : test-secret
+            COSIGN_PASSWORD : passwd
+      - equinixmetal-buildkite/cosign#main:
           image: ghcr.io/my-project/my-image:latest
-          keyless-config:
-            fulcio-url: https://fulcio.sigstore.dev
-            rekor-url: https://rekor.sigstore.dev
-          cosign-version: v0.1.0
+          keyless : false
+          keyed-config:
+            key: cosign.key
+          cosign-version: main
       - equinixmetal-buildkite/trivy#v1.18.3:
-          timeout : 5m0s
-          severity: HIGH,CRITICAL
+          exit-code: 0
+          timeout : "5m0s"
+          severity: "HIGH,CRITICAL"
           ignore-unfixed: true
-          security-checks: vuln,config
+          security-checks: "vuln,config"
+          skip-files: ""
+          skip-dirs: ""
+          image-ref: ""
+      - equinixmetal-buildkite/docker-metadata#v1.0.0:
+          images:
+          - "my-org/my-image"
+          - "image2"
+          extra_tags:
+          - "latest"
+          - "tag2"
 ```
 ## Configuration and Overrides
-* Configurations are stored in `resources/config/conf.yaml` and it has default values.
-* Configurations from the file `resources/config/conf.yaml` can be overridden by command line flags by using the yaml configuration path as below:
+* Configurations are stored in `conf.yaml` and it has default values.
+* Configurations from the file `conf.yaml` can be overridden by command line flags by using the yaml configuration path as below:
 ```
-$ ./dynamic-buildkite-template --overrides plugins.trivy.skip-files="x.txt,y.txt" --overrides plugins.cosign.keyless=false
+$ go run main.go --overrides plugins.trivy.skip-files="x.txt,y.txt" --overrides plugins.cosign.keyless=false
 steps:
   - command: ls
     plugins:
@@ -57,6 +76,73 @@ steps:
           ignore-unfixed: true
           security-checks: vuln,config
           skip-files: 'x.txt,y.txt'
+```
+```
+$ go run main.go --overrides plugins.trivy.skip-files="x.txt,y.txt" --overrides plugins.cosign.keyless=true
+steps:
+  - command: ls
+    plugins:
+      - equinixmetal-buildkite/docker-build#v1.1.0:
+          build-args:
+            - NAME=REPO_NAME
+          push: true
+      - equinixmetal-buildkite/cosign#main:
+          image: ghcr.io/my-project/my-image:latest
+          keyless-config:
+            fulcio-url: 
+            rekor-url: 
+          cosign-version: main
+      - equinixmetal-buildkite/trivy#v1.18.3:
+          exit-code: 0
+          timeout : "5m0s"
+          severity: "HIGH,CRITICAL"
+          ignore-unfixed: true
+          security-checks: "vuln,config"
+          skip-files: "x.txt,y.txt"
+          skip-dirs: ""
+          image-ref: ""
+      - equinixmetal-buildkite/docker-metadata#v1.0.0:
+          images:
+          - "my-org/my-image"
+          - "image2"
+          extra_tags:
+          - "latest"
+          - "tag2"
+```
+### Default conf.yaml for example
+```
+plugins:
+  trivy:
+    exit-code: 0
+    timeout: 5m0s
+    severity: HIGH,CRITICAL
+    ignore-unfixed: true
+    security-checks: vuln,config
+    skip-files: ""
+    skip-dirs: ""
+    image-ref: ""
+    version: ""
+    helm-overrides-files: ""
+
+```
+
+Execute this command to run through a docker run
+```
+$ docker run --mount type=bind,source=${PWD}/conf.yaml,target=/go/src/workspace/dynamic-buildkite-template/conf.yaml ghcr.io/equinixmetal-buildkite/dynamic-buildkite-template:latest
+
+output:
+steps:
+  - command: ls
+    plugins:
+      - equinixmetal-buildkite/trivy#v1.18.3:
+          exit-code: 0
+          timeout : "5m0s"
+          severity: "HIGH,CRITICAL"
+          ignore-unfixed: true
+          security-checks: "vuln,config"
+          skip-files: ""
+          skip-dirs: ""
+          image-ref: ""
 ```
 If you notice you can provide multiple `--overrides` flags and this would in turn collate to a `map[string]string` being passed to the program. The keys in override are in the yaml path format. So for a given config override you can check the path hierarchy in the `conf.yaml` and mention the override accordingly.
 

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// var (
+// 	commandConfig generator.CommandConfig
+// )
+
+// LoadCosignConfigs loads cosign plugin configuration from conf.yaml using "plugins.cosign" key
+func LoadCommandConfigs(cmd *cobra.Command) {
+
+	//g.CommandConfig.CommandConfig = "ls"
+	m, _ := cmd.Flags().GetStringToString("overrides")
+	for k, v := range m {
+		if k == "command" {
+			//fmt.Println("command key found!!!!", v)
+			g.CommandConfig.CommandConfig = v
+			g.CommandConfigEnable = true
+		}
+	}
+}

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -4,18 +4,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// var (
-// 	commandConfig generator.CommandConfig
-// )
-
 // LoadCosignConfigs loads cosign plugin configuration from conf.yaml using "plugins.cosign" key
 func LoadCommandConfigs(cmd *cobra.Command) {
-
-	//g.CommandConfig.CommandConfig = "ls"
 	m, _ := cmd.Flags().GetStringToString("overrides")
 	for k, v := range m {
 		if k == "command" {
-			//fmt.Println("command key found!!!!", v)
 			g.CommandConfig.CommandConfig = v
 			g.CommandConfigEnable = true
 		}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -46,6 +46,7 @@ This Program generates step for the provided plugins with configurations
 		LoadDockerBuildConfigs()
 		// load SSM plugin
 		LoadSSMDataConfigs()
+		LoadCommandConfigs(cmd)
 		// generate the build template
 		err := generator.GenerateBuildSteps(g, os.Stdout, util.TemplateFilePath)
 		if err != nil {

--- a/conf.yaml
+++ b/conf.yaml
@@ -10,40 +10,5 @@ plugins:
     image-ref: ""
     version: ""
     helm-overrides-files: ""
-  cosign:
-    image: "ghcr.io/my-project/my-image:latest"
-    keyless: false
-    keyless-config:
-      fulcio_url: "https://fulcio.sigstore.dev"
-      rekor_url: "https://rekor.sigstore.dev"
-    keyed-config:
-      key: "sample-key"
-    cosign-version: "v0.1.0"
-  docker-metadata:
-    images: ["my-org/my-image","image2"]
-    extra_tags: ["latest","tag2"]
-    title: "sample"
-    licenses: ""
-    vendor: "abc"
-    debug: true
-    docker-metadata-version: ""
-  ssm-buildkite-plugin:
-    ssm-buildkite-version: "v1.0.4"
-    parameters:
-      COSIGN_KEY_SECRET: "test-secret"
-      COSIGN_PASSWORD: "passwd"
-      GITHUB_TOKEN: "token"
-  docker-build:
-    dockerfile: "Dockerfile"
-    context: "."
-    secret-file: "id=mysecret,src=secret-file"
-    tags: 
-      - "my-org/my-image:latest"
-    labels: 
-      - "org.opencontainers.image.source=$BUILDKITE_REPO"
-    build-args: 
-      - "FOO=bar"
-      - "BAZ=qux"
-    push: false
 
 # --overrides plugins.trivy.skip-files="x.txt,y.txt" --overrides plugins.cosign.keyless=false

--- a/generator/command-config.go
+++ b/generator/command-config.go
@@ -1,0 +1,5 @@
+package generator
+
+type CommandConfig struct {
+	CommandConfig string `mapstructure:"command"`
+}

--- a/generator/common-pipeline_test.go
+++ b/generator/common-pipeline_test.go
@@ -156,11 +156,7 @@ func TestCosignStep(t *testing.T) {
 	}
 	expected := `
 steps:
-  - label: ":docker: get cosign key"
-    key: "getkey"
-    command: |
-      #!/bin/bash
-      echo "\$COSIGN_KEY_SECRET" > ${COSIGN_KEY_PATH}
+  - command: ls
     plugins:
       - ssh://git@github.com/equinixmetal/ssm-buildkite-plugin#:
           parameters:

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -8,9 +8,11 @@ type Generator struct {
 	DockerMetadataPluginEnabled bool
 	SSMPluginEnabled            bool
 	DockerBuildPluginEnabled    bool
+	CommandConfigEnable         bool
 	TPConfig                    TrivyPluginConfig
 	CosignConfig                CosignPluginConfig
 	DockerMetadataConfig        DockerMetadataPluginConfig
 	SSMConfig                   SSMPluginConfig
 	DockerBuildConfig           DockerBuildConfig
+	CommandConfig               CommandConfig
 }

--- a/templates/plugins-step.tmpl
+++ b/templates/plugins-step.tmpl
@@ -1,17 +1,46 @@
 steps:
-{{- if .CosignPluginEnabled }}
-{{- if not .CosignConfig.Keyless }}
-  - label: ":docker: get cosign key"
-    key: "getkey"
-    command: |
+{{- if  .CommandConfigEnable }}
+  - command: |
       #!/bin/bash
-      echo "\$COSIGN_KEY_SECRET" > ${COSIGN_KEY_PATH}
+      {{ .CommandConfig.CommandConfig }}
     plugins:
-{{- end }}   
 {{- else }}
   - command: ls
     plugins:
 {{- end }}
+{{- if .DockerBuildPluginEnabled }}
+      - equinixmetal-buildkite/docker-build#{{ .DockerBuildConfig.Version }}:
+          {{- if .DockerBuildConfig.Dockerfile}}
+          dockerfile: {{ .DockerBuildConfig.Dockerfile }}
+          {{- end }}
+          {{- if .DockerBuildConfig.Context}}
+          context : {{ .DockerBuildConfig.Context }}
+          {{- end }}
+          {{- if .DockerBuildConfig.SecretFile}}
+          secret-file: {{ .DockerBuildConfig.SecretFile }}
+          {{- end }}
+          {{- if .DockerBuildConfig.Tags}}
+          tags: 
+          {{- range .DockerBuildConfig.Tags }}
+            - {{ . }}
+          {{- end }}
+          {{- end }}
+          {{- if .DockerBuildConfig.Labels}}
+          labels:
+          {{- range .DockerBuildConfig.Labels }}
+            - {{ . }}
+          {{- end }}
+          {{- end }}
+          {{- if .DockerBuildConfig.BuildArgs}}
+          build-args:
+          {{- range .DockerBuildConfig.BuildArgs }}
+            - {{ . }}
+          {{- end }}
+          {{- end }}
+          {{- if .DockerBuildConfig.Push}}
+          push: {{ .DockerBuildConfig.Push }}
+          {{- end }}
+{{- end}}
 {{- if .CosignPluginEnabled }}
 {{- if not .CosignConfig.Keyless }}
       - ssh://git@github.com/equinixmetal/ssm-buildkite-plugin#{{ .SSMConfig.Version }}:
@@ -100,37 +129,4 @@ steps:
           {{- if .DockerMetadataConfig.Debug }}
           debug: "{{ .DockerMetadataConfig.Debug }}"
           {{- end}}
-{{- end}}
-{{- if .DockerBuildPluginEnabled }}
-      - equinixmetal-buildkite/docker-build#{{ .DockerBuildConfig.Version }}:
-          {{- if .DockerBuildConfig.Dockerfile}}
-          dockerfile: {{ .DockerBuildConfig.Dockerfile }}
-          {{- end }}
-          {{- if .DockerBuildConfig.Context}}
-          context : {{ .DockerBuildConfig.Context }}
-          {{- end }}
-          {{- if .DockerBuildConfig.SecretFile}}
-          secret-file: {{ .DockerBuildConfig.SecretFile }}
-          {{- end }}
-          {{- if .DockerBuildConfig.Tags}}
-          tags: 
-          {{- range .DockerBuildConfig.Tags }}
-            - {{ . }}
-          {{- end }}
-          {{- end }}
-          {{- if .DockerBuildConfig.Labels}}
-          labels:
-          {{- range .DockerBuildConfig.Labels }}
-            - {{ . }}
-          {{- end }}
-          {{- end }}
-          {{- if .DockerBuildConfig.BuildArgs}}
-          build-args:
-          {{- range .DockerBuildConfig.BuildArgs }}
-            - {{ . }}
-          {{- end }}
-          {{- end }}
-          {{- if .DockerBuildConfig.Push}}
-          push: {{ .DockerBuildConfig.Push }}
-          {{- end }}
 {{- end}}


### PR DESCRIPTION
Desc:
Dynamic buildkite template accepts overrides parameters with command parmeter and also uses Conf.yaml for writing conf.yaml, Updated Readme file. It also runs bash commands before plugins are executed.